### PR TITLE
Hotfix cannot generate efbundle

### DIFF
--- a/src/IdentityServer/src/Infrastructure/IdentityServer.Infrastructure.csproj
+++ b/src/IdentityServer/src/Infrastructure/IdentityServer.Infrastructure.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Duende.IdentityServer.EntityFramework" Version="6.1.5" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
-      <PrivateAssets>runtime; build; native; contentfiles; analyzers</PrivateAssets>
+      <PrivateAssets>build; native; contentfiles; analyzers</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.9">


### PR DESCRIPTION
Error message:
`
Could not load file or assembly 'Microsoft.EntityFrameworkCore.Design, Culture=neutral, PublicKeyToken=null'. The system cannot find the file specified.
`
Root cause: Wrong package reference config of `IdentitiServer.Infrastructure` project.